### PR TITLE
feat: add "keep_params" rule

### DIFF
--- a/lib/rules.json
+++ b/lib/rules.json
@@ -71,6 +71,24 @@
           "expected": "https://store.google.com/gb/product/chromecast_google_tv"
         }
       ]
+    },
+    "facebook": {
+      "type": "keep_params",
+      "parameters": [
+        "id",
+        "story_fbid"
+      ],
+      "domain_regex": "(m\\.)?facebook.com",
+      "tests": [
+        {
+          "input": "https://www.facebook.com/reel/1242384407160280?sfnsn=scwspmo",
+          "expected": "https://www.facebook.com/reel/1242384407160280"
+        },
+        {
+          "input": "https://m.facebook.com/story.php?story_fbid=pfbid0HqS6zLZvNrQt6ACvjv3hKq6khpVse437nWSq2jBifKRD5sVH2XRLC3zz8aA7TKkWl&id=4&sfnsn=wiwspmo&mibextid=XzsMCV",
+          "expected": "https://m.facebook.com/story.php?story_fbid=pfbid0HqS6zLZvNrQt6ACvjv3hKq6khpVse437nWSq2jBifKRD5sVH2XRLC3zz8aA7TKkWl&id=4"
+        }
+      ]
     }
   }
 }

--- a/lib/src/commonMain/kotlin/mathilda/json/JsonRule.kt
+++ b/lib/src/commonMain/kotlin/mathilda/json/JsonRule.kt
@@ -62,6 +62,18 @@ internal sealed interface JsonRule {
     ) : JsonRule
 
     @Serializable
+    @SerialName("keep_params")
+    data class JsonKeepParamsRule(
+        override val domains: List<String> = emptyList(),
+        @SerialName("domain_regex")
+        override val domainRegex: String? = null,
+        override val description: String? = null,
+        override val enabled: Boolean = true,
+        override val tests: List<Test> = emptyList(),
+        val parameters: List<String>,
+    ) : JsonRule
+
+    @Serializable
     @SerialName("remove_regex")
     data class JsonRemoveRegexRule(
         override val domains: List<String> = emptyList(),

--- a/lib/src/commonMain/kotlin/mathilda/rule/RuleFactory.kt
+++ b/lib/src/commonMain/kotlin/mathilda/rule/RuleFactory.kt
@@ -3,6 +3,7 @@ package mathilda.rule
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import mathilda.json.JsonRule
+import mathilda.rule.impl.KeepParamsRule
 import mathilda.rule.impl.RemoveParamsRule
 import mathilda.rule.impl.RemoveRegexRule
 import mathilda.rule.impl.TransformRule
@@ -13,6 +14,14 @@ internal object RuleFactory {
 
     private fun fromJsonRule(id: String, rule: JsonRule): Pair<Rule, Boolean> = (when (rule) {
         is JsonRule.JsonRemoveParamsRule -> RemoveParamsRule(
+            id = id,
+            domains = rule.domains.toImmutableList(),
+            domainRegex = rule.domainRegex?.toNullIfBlank(),
+            tests = rule.tests.map(),
+            parameters = rule.parameters.toImmutableList(),
+        )
+
+        is JsonRule.JsonKeepParamsRule -> KeepParamsRule(
             id = id,
             domains = rule.domains.toImmutableList(),
             domainRegex = rule.domainRegex?.toNullIfBlank(),

--- a/lib/src/commonMain/kotlin/mathilda/rule/impl/KeepParamsRule.kt
+++ b/lib/src/commonMain/kotlin/mathilda/rule/impl/KeepParamsRule.kt
@@ -1,0 +1,28 @@
+package mathilda.rule.impl
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import mathilda.rule.BaseRule
+import mathilda.rule.Rule
+
+internal data class KeepParamsRule(
+    override val id: String,
+    override val domains: ImmutableList<String> = persistentListOf(),
+    override val domainRegex: String? = null,
+    override val tests: ImmutableList<Rule.Test> = persistentListOf(),
+    private val parameters: ImmutableList<String>,
+) : BaseRule() {
+
+    override suspend fun execute(url: String) =
+        parameters.joinToString(
+            separator = "|",
+            prefix = "(",
+            postfix = ")"
+        ) { p ->
+            p.replace("?", ".?")
+                .replace("*", ".+?")
+        }.let { parameters ->
+            val regex = Regex("[?&](?!$parameters=)[^&]+")
+            url.replace(regex, "")
+        }
+}

--- a/lib/src/commonTest/kotlin/mathilda/rule/impl/KeepParamsRuleTest.kt
+++ b/lib/src/commonTest/kotlin/mathilda/rule/impl/KeepParamsRuleTest.kt
@@ -1,0 +1,51 @@
+package mathilda.rule.impl
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.test.runTest
+import mathilda.rule.Rule
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class KeepParamsRuleTest {
+
+    @Test
+    fun shouldKeepParameters() {
+        val rule = KeepParamsRule(
+            id = "test1",
+            parameters = persistentListOf("id")
+        )
+
+        runTest {
+            val result = rule("https://www.example.com?utm_source=abc&utm_campaign=xyz&id=123")
+
+            assertIs<Rule.Result.Success>(result)
+            assertEquals(
+                "https://www.example.com?id=123",
+                result.value
+            )
+        }
+    }
+
+    @Test
+    fun shouldKeepWildcardParameters() {
+        val rule = KeepParamsRule(
+            id = "test2",
+            parameters = persistentListOf(
+                "id_*",
+                "test?",
+            )
+        )
+
+        runTest {
+            val result =
+                rule("https://www.example.com?utm_source=abc&ga_campaign=xyz&test1=123&id_x=456")
+
+            assertIs<Rule.Result.Success>(result)
+            assertEquals(
+                "https://www.example.com?test1=123&id_x=456",
+                result.value
+            )
+        }
+    }
+}


### PR DESCRIPTION
Adds a `keep_params` rule for keeping certain parameters and removing everything else.