### PR TITLE
feat: rework slots and add operations

### DIFF
--- a/lib/rules.json
+++ b/lib/rules.json
@@ -21,7 +21,7 @@
     "amazon_product": {
       "type": "transform",
       "input": "((?:https?://)?(?:www\\.)?amazon\\.[^/]*).*/(?:dp?|gp/product)?/([^/?&]*)",
-      "output": "\\1/dp/\\2/",
+      "output": "{{1}}/dp/{{2}}/",
       "domain_regex": "amazon\\.[^/]*.*/(?:dp?|gp/product)?/[^/?&]*",
       "tests": [
         {
@@ -87,6 +87,17 @@
         {
           "input": "https://m.facebook.com/story.php?story_fbid=pfbid0HqS6zLZvNrQt6ACvjv3hKq6khpVse437nWSq2jBifKRD5sVH2XRLC3zz8aA7TKkWl&id=4&sfnsn=wiwspmo&mibextid=XzsMCV",
           "expected": "https://m.facebook.com/story.php?story_fbid=pfbid0HqS6zLZvNrQt6ACvjv3hKq6khpVse437nWSq2jBifKRD5sVH2XRLC3zz8aA7TKkWl&id=4"
+        }
+      ]
+    },
+    "jodel": {
+      "type": "transform",
+      "input": "data=([^?&]+)",
+      "output": "{{1:urldecode:base64decode:jsonvalue($android_url)}}",
+      "tests": [
+        {
+          "input": "http://shared.jodel.com/a/key_live_abZZZZgPxyz82xxxxAAAAdefghi4YYY1?%24identity_id=123456789012345678&feature=shared_post&campaign=image_DE_FrontPage&type=0&duration=0&source=android&data=eyIkY2Fub25pY2FsX2lkZW50aWZpZXIiOiJzYWpcL2JhZGMwZmZlZWJhZGMwZmZlZTAxMjM0NSIsIiRwdWJsaWNseV9pbmRleGFibGUiOiJ0cnVlIiwicG9zdElkIjoiYmFkYzBmZmVlYmFkYzBmZmVlMDEyMzQ1IiwiJGRlc2t0b3BfdXJsIjoiaHR0cHM6XC9cL3NoYXJlLmpvZGVsLmNvbVwvcG9zdD9wb3N0SWQ9YmFkYzBmZmVlYmFkYzBmZmVlMDEyMzQ1IiwicmVmZXJyZXJfaWQiOiJhYmNkZWYwMTIzNDU2Nzg5ZGVhZGMwZGUiLCIkYW5kcm9pZF91cmwiOiJodHRwczpcL1wvc2hhcmUuam9kZWwuY29tXC9wb3N0P3Bvc3RJZD1iYWRjMGZmZWViYWRjMGZmZWUwMTIzNDUiLCIkaW9zX3VybCI6Imh0dHBzOlwvXC9zaGFyZS5qb2RlbC5jb21cL3Bvc3Q%2FcG9zdElkPWJhZGMwZmZlZWJhZGMwZmZlZTAxMjM0NSJ9?channel=copy",
+          "expected": "https://share.jodel.com/post?postId=badc0ffeebadc0ffee012345"
         }
       ]
     }

--- a/lib/src/commonMain/kotlin/mathilda/json/JsonRule.kt
+++ b/lib/src/commonMain/kotlin/mathilda/json/JsonRule.kt
@@ -96,6 +96,5 @@ internal sealed interface JsonRule {
         override val tests: List<Test> = emptyList(),
         val input: String,
         val output: String? = null,
-        val decode: Boolean = false,
     ) : JsonRule
 }

--- a/lib/src/commonMain/kotlin/mathilda/rule/RuleFactory.kt
+++ b/lib/src/commonMain/kotlin/mathilda/rule/RuleFactory.kt
@@ -44,7 +44,6 @@ internal object RuleFactory {
             tests = rule.tests.map(),
             input = rule.input,
             output = rule.output?.toNullIfBlank(),
-            decode = rule.decode,
         )
     }) to rule.enabled
 

--- a/lib/src/commonMain/kotlin/mathilda/rule/impl/TransformRule.kt
+++ b/lib/src/commonMain/kotlin/mathilda/rule/impl/TransformRule.kt
@@ -3,8 +3,11 @@ package mathilda.rule.impl
 import com.eygraber.uri.UriCodec
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.serialization.json.Json
 import mathilda.rule.BaseRule
 import mathilda.rule.Rule
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
 internal data class TransformRule(
     override val id: String,
@@ -13,21 +16,73 @@ internal data class TransformRule(
     override val tests: ImmutableList<Rule.Test> = persistentListOf(),
     private val input: String,
     private val output: String? = null,
-    private val decode: Boolean = false,
 ) : BaseRule() {
 
+    private data class Operation(
+        val name: String,
+        val argument: String?,
+    )
+
+    @OptIn(ExperimentalEncodingApi::class)
     override suspend fun execute(url: String): String {
         val regex = Regex(input)
-        val template = output ?: "\\1"
+        val template = output ?: "{{1}}"
 
         val groups = regex.find(url)?.groupValues
         if (groups == null || groups.size == 1) return url
 
+        val slots = REGEX_SLOTS.findAll(template)
+            .map { result ->
+                val ops = REGEX_SLOTS_OPS.findAll(result.groupValues[2])
+                    .map { result ->
+                        Operation(
+                            name = result.groupValues[1],
+                            argument = result.groupValues[2].ifEmpty { null }
+                        )
+                    }
+                    .toList()
+
+                result.groupValues[1].toInt() to ops
+            }
+            .toMap()
+
         return groups
             .drop(1)
             .foldIndexed(template) { index, curr, group ->
-                val value = if (decode) UriCodec.decode(group) else group
-                curr.replace("\\${index + 1}", value)
+                val index = index + 1
+                val value = slots[index]?.fold(group) { curr, op ->
+                    when (op.name) {
+                        OP_URLDECODE -> UriCodec.decode(curr)
+                        OP_BASE64DECODE -> Base64.Default.decode(curr).decodeToString()
+                        OP_JSONVALUE -> {
+                            if (op.argument == null) throw IllegalArgumentException("No JSON key specified for jsonvalue")
+                            val json = Json.decodeFromString<Map<String, String>>(curr)
+                            json[op.argument].orEmpty()
+                        }
+
+                        else -> throw IllegalArgumentException("Unknown slot operation \"$op\"")
+                    }
+                } ?: group
+
+                curr.replace(Regex("\\{\\{$index.*?}}"), value)
             }
+    }
+
+    private companion object {
+
+        /**
+         * Replacement slots are declared as `{{index}}` or `{{index:operations}}`,
+         * for example `{{1}}` or `{{1:urldecode:base64decode}}`.
+         */
+        private val REGEX_SLOTS = Regex("\\{\\{(\\d)(:.+?)?}}")
+
+        /**
+         * Operations are declared as `:operation` or with an argument `:operation(argument)`.
+         */
+        private val REGEX_SLOTS_OPS = Regex(":([^:(]+)(?:\\(([^)]+)\\))?")
+
+        private const val OP_URLDECODE = "urldecode"
+        private const val OP_BASE64DECODE = "base64decode"
+        private const val OP_JSONVALUE = "jsonvalue"
     }
 }

--- a/lib/src/commonTest/kotlin/mathilda/rule/impl/TransformRuleTest.kt
+++ b/lib/src/commonTest/kotlin/mathilda/rule/impl/TransformRuleTest.kt
@@ -13,7 +13,7 @@ class TransformRuleTest {
         val rule = TransformRule(
             id = "transform",
             input = "[?&]result=([^&#]*)",
-            decode = true,
+            output = "{{1:urldecode}}"
         )
 
         runTest {
@@ -33,12 +33,32 @@ class TransformRuleTest {
         val rule = TransformRule(
             id = "transform",
             input = "[?&]id=(.*?)&title=([^&#]*)",
-            output = "https://www.result.example?id=\\1&title=\\2"
+            output = "https://www.result.example?id={{1}}&title={{2}}"
         )
 
         runTest {
             val result =
                 rule("https://www.example.com?id=12345&title=HelloWorld")
+
+            assertIs<Rule.Result.Success>(result)
+            assertEquals(
+                "https://www.result.example?id=12345&title=HelloWorld",
+                result.value
+            )
+        }
+    }
+
+    @Test
+    fun shouldBase64Decode() {
+        val rule = TransformRule(
+            id = "transform",
+            input = "[?&]id=(.*?)&title=([^&#]*)",
+            output = "https://www.result.example?id={{1}}&title={{2:urldecode:base64decode}}",
+        )
+
+        runTest {
+            val result =
+                rule("https://www.example.com?id=12345&title=SGVsbG9Xb3JsZA%3D%3D")
 
             assertIs<Rule.Result.Success>(result)
             assertEquals(


### PR DESCRIPTION
This PR changes the slot syntax from `\\index` to `{{index}}` and also adds optional slot operations. Currently

- `urldecode`
- `base64decode`
- `jsonvalue(key)`

are supported.